### PR TITLE
Compiler flag refinements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,9 +43,6 @@ let package = Package(
                 .product(name: "Crypto", package: "swift-crypto", condition: .when(platforms: .nonDarwin)),
                 .product(name: "_CryptoExtras", package: "swift-crypto", condition: .when(platforms: .nonDarwin)),
                 .product(name: "CryptoSwift", package: "CryptoSwift", condition: .when(platforms: .nonDarwin)),
-            ],
-            swiftSettings: [
-                .enableUpcomingFeature("ExistentialAny"),
             ]),
         .testTarget(
             name: "JWSETKitTests",

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
                 .product(name: "CryptoSwift", package: "CryptoSwift", condition: .when(platforms: .nonDarwin)),
             ],
             swiftSettings: [
-                .enableUpcomingFeature("ExistentialAny")
+                .enableUpcomingFeature("ExistentialAny"),
             ]),
         .testTarget(
             name: "JWSETKitTests",

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -45,7 +45,8 @@ let package = Package(
                 .product(name: "CryptoSwift", package: "CryptoSwift", condition: .when(platforms: .nonDarwin)),
             ],
             swiftSettings: [
-                .enableUpcomingFeature("ExistentialAny")
+                .enableExperimentalFeature("StrictConcurrency=complete"),
+                .enableUpcomingFeature("ExistentialAny"),
             ]),
         .testTarget(
             name: "JWSETKitTests",

--- a/Sources/JWSETKit/Base/ProtectedContainer.swift
+++ b/Sources/JWSETKit/Base/ProtectedContainer.swift
@@ -34,7 +34,7 @@ extension ProtectedWebContainer {
         // No required field by default thus no validation is needed.
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(encoded.urlBase64EncodedString())
     }
@@ -58,7 +58,7 @@ public struct ProtectedDataWebContainer: ProtectedWebContainer, Codable {
         self.encoded = encoded
     }
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         
         let encoded = try container.decode(String.self)
@@ -135,7 +135,7 @@ public struct ProtectedJSONWebContainer<Container: JSONWebContainer>: TypedProte
         self._protected = try JSONEncoder().encode(value)
     }
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         
         let encoded = try container.decode(String.self)

--- a/Sources/JWSETKit/Base/Storage.swift
+++ b/Sources/JWSETKit/Base/Storage.swift
@@ -123,7 +123,7 @@ public struct JSONWebValueStorage: Codable, Hashable, ExpressibleByDictionaryLit
         self.storage = .init(uniqueKeysWithValues: elements)
     }
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         if let claims = try? container.decode([String: AnyCodable].self) {
             self.storage = claims
@@ -145,7 +145,7 @@ public struct JSONWebValueStorage: Codable, Hashable, ExpressibleByDictionaryLit
         return result
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(storage)
     }
@@ -219,7 +219,7 @@ public struct JSONWebValueStorage: Codable, Hashable, ExpressibleByDictionaryLit
                 guard let data = try? JSONEncoder().encode(value) else { return nil }
                 return try? JSONDecoder().decode(type, from: data) as? T
             }
-        case is Encodable.Type:
+        case is any Encodable.Type:
             return value as? T
         default:
             assertionFailure("Unknown storage type")

--- a/Sources/JWSETKit/Base/WebContainer.swift
+++ b/Sources/JWSETKit/Base/WebContainer.swift
@@ -34,13 +34,13 @@ extension JSONWebContainer {
         initializer(&self)
     }
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         self = try Self(storage: .init())
         let container = try decoder.singleValueContainer()
         self.storage = try container.decode(JSONWebValueStorage.self)
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(storage)
     }

--- a/Sources/JWSETKit/Cryptography/Algorithms/Algorithms.swift
+++ b/Sources/JWSETKit/Cryptography/Algorithms/Algorithms.swift
@@ -37,12 +37,12 @@ extension JSONWebAlgorithm {
         self.init(value)
     }
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         try self.init(container.decode(String.self))
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(rawValue)
     }
@@ -132,12 +132,12 @@ public struct JSONWebKeyType: RawRepresentable, Hashable, Codable, ExpressibleBy
         self.rawValue = value.trimmingCharacters(in: .whitespaces)
     }
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         self.rawValue = try container.decode(String.self)
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(rawValue)
     }
@@ -168,12 +168,12 @@ public struct JSONWebKeyCurve: RawRepresentable, Hashable, Codable, ExpressibleB
         self.rawValue = value.trimmingCharacters(in: .whitespaces)
     }
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         self.rawValue = try container.decode(String.self)
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(rawValue)
     }

--- a/Sources/JWSETKit/Cryptography/Algorithms/Compression.swift
+++ b/Sources/JWSETKit/Cryptography/Algorithms/Compression.swift
@@ -46,12 +46,12 @@ public struct JSONWebCompressionAlgorithm: RawRepresentable, Hashable, Codable, 
         self.rawValue = value.trimmingCharacters(in: .whitespaces)
     }
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         self.rawValue = try container.decode(String.self)
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(rawValue)
     }

--- a/Sources/JWSETKit/Cryptography/Keys.swift
+++ b/Sources/JWSETKit/Cryptography/Keys.swift
@@ -44,12 +44,12 @@ extension JSONWebKey {
         self = try Self.create(storage: JSONDecoder().decode(JSONWebValueStorage.self, from: data))
     }
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         self = try Self.create(storage: container.decode(JSONWebValueStorage.self))
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(storage)
     }
@@ -306,13 +306,13 @@ public struct JSONWebKeySet: Codable, Hashable {
         self.keys = keys
     }
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let keys = try container.decode([AnyJSONWebKey].self, forKey: .keys)
         self.keys = try keys.map { try $0.specialized() }
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(keys.map(\.storage), forKey: .keys)
     }

--- a/Sources/JWSETKit/Entities/JOSE/JOSEHeader.swift
+++ b/Sources/JWSETKit/Entities/JOSE/JOSEHeader.swift
@@ -71,12 +71,12 @@ public struct JSONWebContentType: RawRepresentable, Hashable, Codable, Expressib
         self.rawValue = value.trimmingCharacters(in: .whitespaces)
     }
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         self.rawValue = try container.decode(String.self)
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(rawValue)
     }

--- a/Sources/JWSETKit/Entities/JWE/JWECodable.swift
+++ b/Sources/JWSETKit/Entities/JWE/JWECodable.swift
@@ -77,7 +77,7 @@ extension JSONWebEncryption: Codable {
         case tag
     }
     
-    private init(string: String, codingPath: [CodingKey]) throws {
+    private init(string: String, codingPath: [any CodingKey]) throws {
         let sections = string
             .components(separatedBy: ".")
             .map { Data(urlBase64Encoded: $0) }
@@ -92,7 +92,7 @@ extension JSONWebEncryption: Codable {
         self.sealed = .init(iv: iv ?? .init(), ciphertext: ciphertext ?? .init(), tag: tag ?? .init())
     }
     
-    private init(object decoder: Decoder) throws {
+    private init(object decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.header = try JSONWebEncryptionHeader(from: decoder)
         if let recipientsValue = try? container.decode([JSONWebEncryptionRecipient].self, forKey: .recipients) {
@@ -109,7 +109,7 @@ extension JSONWebEncryption: Codable {
         self.sealed = .init(iv: iv ?? .init(), ciphertext: ciphertext ?? .init(), tag: tag ?? .init())
     }
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         if let stringContainer = try? decoder.singleValueContainer(), let value = try? stringContainer.decode(String.self) {
             try self.init(string: value, codingPath: decoder.codingPath)
         } else {
@@ -117,7 +117,7 @@ extension JSONWebEncryption: Codable {
         }
     }
     
-    fileprivate func encodeAsString(_ encoder: Encoder) throws {
+    fileprivate func encodeAsString(_ encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         let value = [
             header.protected.encoded,
@@ -131,7 +131,7 @@ extension JSONWebEncryption: Codable {
         try container.encode(value)
     }
     
-    fileprivate func encodeAsCompleteJSON(_ encoder: Encoder) throws {
+    fileprivate func encodeAsCompleteJSON(_ encoder: any Encoder) throws {
         try header.encode(to: encoder)
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(recipients, forKey: .recipients)
@@ -141,7 +141,7 @@ extension JSONWebEncryption: Codable {
         try container.encode(sealed.tag, forKey: .tag)
     }
     
-    fileprivate func encodeAsFlattenedJSON(_ encoder: Encoder) throws {
+    fileprivate func encodeAsFlattenedJSON(_ encoder: any Encoder) throws {
         try header.encode(to: encoder)
         try recipients.first?.encode(to: encoder)
         var container = encoder.container(keyedBy: CodingKeys.self)
@@ -160,7 +160,7 @@ extension JSONWebEncryption: Codable {
         }
     }
     
-    fileprivate func encodeFunction(for representation: JSONWebEncryptionRepresentation) -> (_ encoder: Encoder) throws -> Void {
+    fileprivate func encodeFunction(for representation: JSONWebEncryptionRepresentation) -> (_ encoder: any Encoder) throws -> Void {
         switch representation {
         case .compact:
             return encodeAsString
@@ -178,7 +178,7 @@ extension JSONWebEncryption: Codable {
         }
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         let representation = encoder.userInfo[.jweEncodedRepresentation] as? JSONWebEncryptionRepresentation ?? .compact
         try encodeFunction(for: representation)(encoder)
     }
@@ -197,7 +197,7 @@ public struct JSONWebEncryptionCodableConfiguration: Sendable {
 extension JSONWebEncryption: EncodableWithConfiguration {
     public typealias EncodingConfiguration = JSONWebEncryptionCodableConfiguration
     
-    public func encode(to encoder: Encoder, configuration: JSONWebEncryptionCodableConfiguration) throws {
+    public func encode(to encoder: any Encoder, configuration: JSONWebEncryptionCodableConfiguration) throws {
         try encodeFunction(for: configuration.representation)(encoder)
     }
 }

--- a/Sources/JWSETKit/Entities/JWE/JWEHeader.swift
+++ b/Sources/JWSETKit/Entities/JWE/JWEHeader.swift
@@ -56,14 +56,14 @@ public struct JSONWebEncryptionHeader: Hashable, Sendable, Codable {
         self.unprotected = unprotected
     }
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         self.protected = try container.decode(ProtectedJSONWebContainer<JOSEHeader>.self, forKey: .protected)
         self.unprotected = try container.decodeIfPresent(JOSEHeader.self, forKey: .unprotected)
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         try protected.validate()
         
         var container = encoder.container(keyedBy: CodingKeys.self)

--- a/Sources/JWSETKit/Entities/JWE/JWERecipient.swift
+++ b/Sources/JWSETKit/Entities/JWE/JWERecipient.swift
@@ -38,7 +38,7 @@ public struct JSONWebEncryptionRecipient: Hashable, Sendable, Codable {
         self.encrypedKey = encrypedKey
     }
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         self.header = try container.decodeIfPresent(JOSEHeader.self, forKey: JSONWebEncryptionRecipient.CodingKeys.header)
@@ -49,7 +49,7 @@ public struct JSONWebEncryptionRecipient: Hashable, Sendable, Codable {
         self.encrypedKey = key
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         
         if let header, !header.storage.storageKeys.isEmpty {

--- a/Sources/JWSETKit/Entities/JWS/JWSCodable.swift
+++ b/Sources/JWSETKit/Entities/JWS/JWSCodable.swift
@@ -85,7 +85,7 @@ extension CodingUserInfoKey {
 }
 
 extension JSONWebSignature: Codable {
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         if let stringContainer = try? decoder.singleValueContainer(), let value = try? stringContainer.decode(String.self) {
             let sections = value
                 .components(separatedBy: ".")
@@ -123,7 +123,7 @@ extension JSONWebSignature: Codable {
         }
     }
     
-    fileprivate func encodeAsString(_ encoder: Encoder) throws {
+    fileprivate func encodeAsString(_ encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         guard let signature = signatures.first else {
             try container.encode("..")
@@ -140,7 +140,7 @@ extension JSONWebSignature: Codable {
         try container.encode(value)
     }
     
-    fileprivate func encodeAsDetachedString(_ encoder: Encoder) throws {
+    fileprivate func encodeAsDetachedString(_ encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         guard let signature = signatures.first else {
             try container.encode("..")
@@ -154,13 +154,13 @@ extension JSONWebSignature: Codable {
         try container.encode(value)
     }
     
-    fileprivate func encodeAsCompleteJSON(_ encoder: Encoder) throws {
+    fileprivate func encodeAsCompleteJSON(_ encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(payload.encoded.urlBase64EncodedString(), forKey: .payload)
         try container.encode(signatures, forKey: .signatures)
     }
     
-    fileprivate func encodeAsFlattenedJSON(_ encoder: Encoder) throws {
+    fileprivate func encodeAsFlattenedJSON(_ encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(payload.encoded.urlBase64EncodedString(), forKey: .payload)
         var headerContainer = encoder.container(keyedBy: JSONWebSignatureHeader.CodingKeys.self)
@@ -186,7 +186,7 @@ extension JSONWebSignature: Codable {
         }
     }
     
-    fileprivate func encodeFunction(for representation: JSONWebSignatureRepresentation) -> (_ encoder: Encoder) throws -> Void {
+    fileprivate func encodeFunction(for representation: JSONWebSignatureRepresentation) -> (_ encoder: any Encoder) throws -> Void {
         var representation = representation
         if representation == .automatic {
             representation = bestRepresentation()
@@ -212,7 +212,7 @@ extension JSONWebSignature: Codable {
         }
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         try validate()
         let representation = encoder.userInfo[.jwsEncodedRepresentation] as? JSONWebSignatureRepresentation ?? .automatic
         try encodeFunction(for: representation)(encoder)
@@ -232,7 +232,7 @@ public struct JSONWebSignatureCodableConfiguration: Sendable {
 extension JSONWebSignature: EncodableWithConfiguration {
     public typealias EncodingConfiguration = JSONWebSignatureCodableConfiguration
     
-    public func encode(to encoder: Encoder, configuration: JSONWebSignatureCodableConfiguration) throws {
+    public func encode(to encoder: any Encoder, configuration: JSONWebSignatureCodableConfiguration) throws {
         try validate()
         try encodeFunction(for: configuration.representation)(encoder)
     }

--- a/Sources/JWSETKit/Entities/JWS/JWSHeader.swift
+++ b/Sources/JWSETKit/Entities/JWS/JWSHeader.swift
@@ -55,7 +55,7 @@ public struct JSONWebSignatureHeader: Hashable, Codable, Sendable {
         self.signature = signature
     }
     
-    public init(from decoder: Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         self.protected = try container.decode(ProtectedJSONWebContainer<JOSEHeader>.self, forKey: .protected)
@@ -65,7 +65,7 @@ public struct JSONWebSignatureHeader: Hashable, Codable, Sendable {
         self.signature = Data(urlBase64Encoded: signatureString) ?? .init()
     }
     
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         try protected.validate()
         
         var container = encoder.container(keyedBy: CodingKeys.self)

--- a/Sources/JWSETKit/Extensions/Localizing.swift
+++ b/Sources/JWSETKit/Extensions/Localizing.swift
@@ -35,11 +35,11 @@ extension String {
 #endif
     }
     
-    init(localizingKey key: String, _ arguments: CVarArg...) {
+    init(localizingKey key: String, _ arguments: any CVarArg...) {
         self = .init(format: .init(localizingKey: key), arguments: arguments)
     }
     
-    init(localizingKey key: String, arguments: [CVarArg]) {
+    init(localizingKey key: String, arguments: [any CVarArg]) {
         self = .init(format: .init(localizingKey: key), arguments: arguments)
     }
 }


### PR DESCRIPTION
* Introduce a dedicated `Package.swift` for Swift 5.9+ to be able to use the new "experimental feature" flag called `StrictConcurrency` with the maximum value of `complete`.
* Remove the concurrency-related `unsafeFlags` from Swift 5.8's `Package.swift`.
* Enable the `ExistentialAny` "upcoming feature" flag which is planned to be the default behavior in Swift 6.
* Modify source files to comply with `ExistentialAny`.

These changes have no technical effect on current users of the package.