### PR TITLE
Chore: fix a bunch of typos in the documentations and the code itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For detailed usage and API documentation, check [the documentation][docs].
 | JWS Multiple Signatures        | :white_check_mark: | :x:                | :x:                | :x:                 |
 | JWS Unencoded/Detached Payload | :white_check_mark: | :x:                | :x:                | :x:                 |
 | JSON Web Token (JWT)           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:  |
-| JWT Signature Verfication      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                 |
+| JWT Signature Verification     | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                 |
 | JWT Expire/NotBefore Validity  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                 |
 | JSON Web Encryption (JWE)      | :white_check_mark: | :x:                | :white_check_mark: | :x:                 |
 | Support [CommonCrypto] Keys    | :white_check_mark: | :x:                | :x:                | :x:                 |

--- a/Sources/JWSETKit/Base/ProtectedContainer.swift
+++ b/Sources/JWSETKit/Base/ProtectedContainer.swift
@@ -122,7 +122,7 @@ public struct ProtectedDataWebContainer: ProtectedWebContainer, Codable {
 
 /// A JSON Web Signature/Encryption (JWS/JWE) header or payload with can be signed.
 ///
-/// This cotainer preserves original data to keep consistancy of signature as re-encoding payload
+/// This container preserves original data to keep consistency of signature as re-encoding payload
 /// may change sorting.
 @frozen
 public struct ProtectedJSONWebContainer<Container: JSONWebContainer>: TypedProtectedWebContainer, Codable {

--- a/Sources/JWSETKit/Base/ProtectedContainer.swift
+++ b/Sources/JWSETKit/Base/ProtectedContainer.swift
@@ -173,7 +173,7 @@ public struct ProtectedJSONWebContainer<Container: JSONWebContainer>: TypedProte
     
     /// Initialized protected container from a JOSE data.
     ///
-    /// - Note: If empty encoded data is given, value will be initialzed as empty object.
+    /// - Note: If empty encoded data is given, value will be initialized as empty object.
     ///
     /// - Parameter protected: Serialzed json object but **not** in `base64url` .
     public init(encoded: Data) throws {

--- a/Sources/JWSETKit/Base/Storage.swift
+++ b/Sources/JWSETKit/Base/Storage.swift
@@ -209,7 +209,7 @@ public struct JSONWebValueStorage: Codable, Hashable, CustomReflectable, Express
             // "IANA" presentation is expected, and UUID where lower-cased is preferred.
             //
             // These well known types are handled specially to prevent mis-encoding JWS/JWT
-            // when using a `JSONEncoder` with incorrect data/date formattting strategies.
+            // when using a `JSONEncoder` with incorrect data/date formatting strategies.
             return type.castValue(value) as? T
         case let type as any Decodable.Type:
             // Some data types are same in JSON while have different types

--- a/Sources/JWSETKit/Base/Storage.swift
+++ b/Sources/JWSETKit/Base/Storage.swift
@@ -124,7 +124,7 @@ public struct JSONWebValueStorage: Codable, Hashable, CustomReflectable, Express
         self.storage = [:]
     }
     
-    /// Initialzes storage with given key values.
+    /// Initializes storage with given key values.
     public init(_ elements: [String: any ValueType]) {
         self.storage = .init(uniqueKeysWithValues: elements.map {
             ($0, AnyCodable($1))

--- a/Sources/JWSETKit/Cryptography/Algorithms/KeyEncryption.swift
+++ b/Sources/JWSETKit/Cryptography/Algorithms/KeyEncryption.swift
@@ -286,7 +286,7 @@ extension JSONWebKeyEncryptionAlgorithm {
             header.pbes2Count = iterations
         }
         let salt = Data(keyEncryptingAlgorithm.rawValue.utf8) + [0x00] + (header.pbes2Salt ?? .init())
-        let key = try SymmetricKey.paswordBased2DerivedSymmetricKey(
+        let key = try SymmetricKey.passwordBased2DerivedSymmetricKey(
             password: password, salt: salt, iterations: iterations,
             length: keyEncryptingAlgorithm.keyLength.map { $0 / 8 }, hashFunction: keyEncryptingAlgorithm.hashFunction.unsafelyUnwrapped
         )
@@ -357,7 +357,7 @@ extension JSONWebKeyEncryptionAlgorithm {
             throw JSONWebKeyError.keyNotFound
         }
         let salt = Data(algorithm.rawValue.utf8) + [0x00] + (header.pbes2Salt ?? .init())
-        kek = try SymmetricKey.paswordBased2DerivedSymmetricKey(
+        kek = try SymmetricKey.passwordBased2DerivedSymmetricKey(
             password: password, salt: salt, iterations: iterations, length: algorithm.keyLength.map { $0 / 8 },
             hashFunction: hashFunction
         )

--- a/Sources/JWSETKit/Cryptography/KeyParser.swift
+++ b/Sources/JWSETKit/Cryptography/KeyParser.swift
@@ -49,18 +49,18 @@ extension AnyJSONWebKey {
 
 /// A specializer that can convert a `AnyJSONWebKey` to a specific `JSONWebKey` type.
 public protocol JSONWebKeySpecializer {
-    /// Specializes a `AnyJSONWebKey` to a specific `JSONWebKey` type, returns `nil` if key is not appropiate.
+    /// Specializes a `AnyJSONWebKey` to a specific `JSONWebKey` type, returns `nil` if key is not appropriate.
     ///
     /// - Parameter key: The key to specialize.
-    /// - Returns: A specific `JSONWebKey` type, or `nil` if the key is not appropiate.
+    /// - Returns: A specific `JSONWebKey` type, or `nil` if the key is not appropriate.
     static func specialize(_ key: AnyJSONWebKey) throws -> (any JSONWebKey)?
     
-    /// Deserializes a key from a data, returns `nil` if key is not appropiate.
+    /// Deserializes a key from a data, returns `nil` if key is not appropriate.
     ///
     /// - Parameters:
     ///   - key: The key data to deserialize.
     ///   - format: The format of the key data.
-    ///   - Returns: A specific `JSONWebKey` type, or `nil` if the key is not appropiate.
+    ///   - Returns: A specific `JSONWebKey` type, or `nil` if the key is not appropriate.
     static func deserialize<D>(key: D, format: JSONWebKeyFormat) throws -> (any JSONWebKey)? where D: DataProtocol
 }
 

--- a/Sources/JWSETKit/Cryptography/Keys.swift
+++ b/Sources/JWSETKit/Cryptography/Keys.swift
@@ -462,7 +462,7 @@ public protocol JSONWebSymmetricSigningKey: JSONWebSigningKey, JSONWebKeySymmetr
 
 /// A type-erased general container for a JSON Web Key (JWK).
 ///
-/// - Note: To create a key able to do operations (sign, verify, encrypt, decrypt) use `specialzed()` method.
+/// - Note: To create a key able to do operations (sign, verify, encrypt, decrypt) use `specialized()` method.
 @frozen
 public struct AnyJSONWebKey: MutableJSONWebKey, Sendable {
     public var storage: JSONWebValueStorage

--- a/Sources/JWSETKit/Cryptography/Symmetric/PBKDF2.swift
+++ b/Sources/JWSETKit/Cryptography/Symmetric/PBKDF2.swift
@@ -31,7 +31,7 @@ extension SymmetricKey {
     ///   - iterations: Iteration count, a positive integer.
     ///
     /// - Returns: A symmetric key derived from parameters.
-    public static func paswordBased2DerivedSymmetricKey<PD, SD, H>(
+    public static func passwordBased2DerivedSymmetricKey<PD, SD, H>(
         password: PD, salt: SD, iterations: Int, length: Int? = nil, hashFunction: H.Type
     ) throws -> SymmetricKey where PD: DataProtocol, SD: DataProtocol, H: HashFunction {
         let length = length ?? hashFunction.Digest.byteCount

--- a/Sources/JWSETKit/Documentation.docc/Extensions/JWE.md
+++ b/Sources/JWSETKit/Documentation.docc/Extensions/JWE.md
@@ -22,7 +22,7 @@ Now it is possible to decrypt data using private key,
 let data = try jwe.decrypt(using: keyEncryptionKey)
 ```
 
-Decrypted content now can be deserialzed. For example if content is JWT claims,
+Decrypted content now can be deserialized. For example if content is JWT claims,
 
 ```swift
 let claims = JSONDecoder().decode(JSONWebTokenClaims.self, from: data)

--- a/Sources/JWSETKit/Documentation.docc/Extensions/JWE.md
+++ b/Sources/JWSETKit/Documentation.docc/Extensions/JWE.md
@@ -60,7 +60,7 @@ let jwe = try! JSONWebEncryption(
 let jweString = try! String(jwe: jwe)
 ```
 
-In case multiple recipient support is neccessary or a unknown newly registered key type
+In case multiple recipient support is necessary or a unknown newly registered key type
 is used for encryption, you may first create encrypted key and sealed box and use 
 ``JSONWebEncryption/init(header:recipients:sealed:additionalAuthenticatedData:)``
 to create JWE instance from parts.

--- a/Sources/JWSETKit/Documentation.docc/Extensions/JWS.md
+++ b/Sources/JWSETKit/Documentation.docc/Extensions/JWS.md
@@ -66,7 +66,7 @@ do {
 ```
 
 Using RSA key for `RS256`, `PS256`, etc. according to `alg` header.
-Also usable for Eliptic-Curve, but `CryptoKit.P256.Signing` is recommended.
+Also usable for Elliptic-Curve, but `CryptoKit.P256.Signing` is recommended.
 
 ```swift
 let attributes: CFDictionary =

--- a/Sources/JWSETKit/Documentation.docc/Manuals/3-Cryptography.md
+++ b/Sources/JWSETKit/Documentation.docc/Manuals/3-Cryptography.md
@@ -85,7 +85,7 @@ Supports `A128CBC-HS256`, `A192CBC-HS384` and `A256CBC-HS512` algorithms for enc
 
 Usable for decryption and encrypting. See ``JSONWebKeyAESCBCHMAC``.
 
-### Eliptic-Curve
+### Elliptic-Curve
 
 #### Public Key
 

--- a/Sources/JWSETKit/Entities/JOSE/JOSEHeader.swift
+++ b/Sources/JWSETKit/Entities/JOSE/JOSEHeader.swift
@@ -151,7 +151,7 @@ extension JSONWebContentType {
         self.init(rawValue: mimeType)
     }
  
-    /// Returns a Uniform Type Identifer corresponding to MIME type.
+    /// Returns a Uniform Type Identifier corresponding to MIME type.
     public var utType: UTType? {
         let mimeType = mimeType
         let conformingType: UTType = mimeType.hasSuffix("+json") ? .json : .data

--- a/Sources/JWSETKit/Entities/JWE/JWE.swift
+++ b/Sources/JWSETKit/Entities/JWE/JWE.swift
@@ -78,7 +78,7 @@ public struct JSONWebEncryption: Hashable, Sendable {
     
     /// Creates new JWE container with encrypted data using given recipients public key.
     ///
-    /// - Note: `algorithm` and `encryptionAlgorithm` paramteres in `protected` shall
+    /// - Note: `algorithm` and `encryptionAlgorithm` parameters in `protected` shall
     ///         be overrided by `keyEncryptingAlgorithm` and `contentEncryptionAlgorithm`.
     ///
     /// - Important: For `PBES2` algorithms, provide password using
@@ -161,7 +161,7 @@ public struct JSONWebEncryption: Hashable, Sendable {
     
     /// Creates new JWE container with encrypted data using given recipients public key.
     ///
-    /// - Note: `algorithm` and `encryptionAlgorithm` paramteres in `protected` shall
+    /// - Note: `algorithm` and `encryptionAlgorithm` parameters in `protected` shall
     ///         be overrided by `keyEncryptingAlgorithm` and `contentEncryptionAlgorithm`.
     ///
     /// - Important: For `PBES2` algorithms, provide password using

--- a/Sources/JWSETKit/Entities/JWE/JWE.swift
+++ b/Sources/JWSETKit/Entities/JWE/JWE.swift
@@ -257,7 +257,7 @@ public struct JSONWebEncryption: Hashable, Sendable {
         }
     }
     
-    /// Initialzes JWE using Base64URL encoded String.
+    /// Initializes JWE using Base64URL encoded String.
     ///
     /// - Parameter string: Base64URL encoded String.
     public init<S: StringProtocol>(from string: S) throws {

--- a/Sources/JWSETKit/Entities/JWE/JWE.swift
+++ b/Sources/JWSETKit/Entities/JWE/JWE.swift
@@ -150,7 +150,7 @@ public struct JSONWebEncryption: Hashable, Sendable {
             protected: ProtectedJSONWebContainer(value: header),
             unprotected: unprotected
         )
-        let authenticating = self.header.protected.autenticating(additionalAuthenticatedData: additionalAuthenticatedData)
+        let authenticating = self.header.protected.authenticating(additionalAuthenticatedData: additionalAuthenticatedData)
         self.sealed = try cek.seal(
             plainData,
             authenticating: authenticating,
@@ -233,7 +233,7 @@ public struct JSONWebEncryption: Hashable, Sendable {
             self.recipients = [.init(encryptedKey: mutatedEncryptedKey)]
         }
         self.header = try .init(protected: protected, unprotected: unprotected)
-        let authenticating = protected.autenticating(additionalAuthenticatedData: additionalAuthenticatedData)
+        let authenticating = protected.authenticating(additionalAuthenticatedData: additionalAuthenticatedData)
         self.sealed = try cek.seal(
             plainData,
             iv: nonce,
@@ -291,7 +291,7 @@ public struct JSONWebEncryption: Hashable, Sendable {
             throw JSONWebKeyError.keyNotFound
         }
         let cek = try SymmetricKey(data: decryptingKey.decrypt(targetEncryptedKey, using: algorithm))
-        let authenticatingData = header.protected.autenticating(additionalAuthenticatedData: additionalAuthenticatedData)
+        let authenticatingData = header.protected.authenticating(additionalAuthenticatedData: additionalAuthenticatedData)
         let content = try cek.open(sealed, authenticating: authenticatingData, using: contentEncAlgorithm)
         
         if let compressor = combinedHeader.compressionAlgorithm?.compressor {
@@ -341,7 +341,7 @@ extension String {
 }
 
 extension ProtectedWebContainer {
-    fileprivate func autenticating(additionalAuthenticatedData: Data?) -> Data {
+    fileprivate func authenticating(additionalAuthenticatedData: Data?) -> Data {
         let suffix: Data
         if let additionalAuthenticatedData, !additionalAuthenticatedData.isEmpty {
             suffix = Data(".".utf8) + additionalAuthenticatedData.urlBase64EncodedData()

--- a/Sources/JWSETKit/Entities/JWE/JWE.swift
+++ b/Sources/JWSETKit/Entities/JWE/JWE.swift
@@ -32,7 +32,7 @@ public struct JSONWebEncryption: Hashable, Sendable {
     /// to produce the ciphertext and the Authentication Tag.
     public var encryptedKey: Data? {
         get {
-            recipients.first?.encrypedKey
+            recipients.first?.encryptedKey
         }
         set {
             guard let newValue else {
@@ -40,9 +40,9 @@ public struct JSONWebEncryption: Hashable, Sendable {
                 return
             }
             if !recipients.isEmpty {
-                recipients[0].encrypedKey = newValue
+                recipients[0].encryptedKey = newValue
             } else {
-                recipients = [.init(encrypedKey: newValue)]
+                recipients = [.init(encryptedKey: newValue)]
             }
         }
     }
@@ -71,7 +71,7 @@ public struct JSONWebEncryption: Hashable, Sendable {
     ///   - sealed: Contains JWE Initialization Vector, JWE Ciphertext and JWE Authentication Tag.
     public init(protected: ProtectedJSONWebContainer<JOSEHeader>, encryptedKey: Data, sealed: SealedData) throws {
         self.header = try .init(protected: protected)
-        self.recipients = [.init(encrypedKey: encryptedKey)]
+        self.recipients = [.init(encryptedKey: encryptedKey)]
         self.sealed = sealed
         self.additionalAuthenticatedData = nil
     }
@@ -144,7 +144,7 @@ public struct JSONWebEncryption: Hashable, Sendable {
                 throw JSONWebKeyError.keyNotFound
             }
             let mutatedEncryptedKey = try handler(&header, keyEncryptingAlgorithm, keyEncryptionKey, contentEncryptionAlgorithm, cekData)
-            self.recipients = [.init(encrypedKey: mutatedEncryptedKey)]
+            self.recipients = [.init(encryptedKey: mutatedEncryptedKey)]
         }
         self.header = try .init(
             protected: ProtectedJSONWebContainer(value: header),
@@ -230,7 +230,7 @@ public struct JSONWebEncryption: Hashable, Sendable {
             guard modifiedHeader == mergedHeader else {
                 throw JSONWebKeyError.operationNotAllowed
             }
-            self.recipients = [.init(encrypedKey: mutatedEncryptedKey)]
+            self.recipients = [.init(encryptedKey: mutatedEncryptedKey)]
         }
         self.header = try .init(protected: protected, unprotected: unprotected)
         let authenticating = protected.autenticating(additionalAuthenticatedData: additionalAuthenticatedData)
@@ -280,7 +280,7 @@ public struct JSONWebEncryption: Hashable, Sendable {
             throw JSONWebKeyError.unknownAlgorithm
         }
         
-        var targetEncryptedKey = recipient?.encrypedKey ?? .init()
+        var targetEncryptedKey = recipient?.encryptedKey ?? .init()
         guard let algorithm = combinedHeader.algorithm?.specialized() as? JSONWebKeyEncryptionAlgorithm else {
             throw JSONWebKeyError.unknownAlgorithm
         }

--- a/Sources/JWSETKit/Entities/JWE/JWECodable.swift
+++ b/Sources/JWSETKit/Entities/JWE/JWECodable.swift
@@ -64,7 +64,7 @@ public enum JSONWebEncryptionRepresentation: Sendable {
 }
 
 extension CodingUserInfoKey {
-    /// Changes serialzation of JWE.
+    /// Changes serialization of JWE.
     ///
     /// Default value is `.compact` if not set.
     public static var jweEncodedRepresentation: Self {

--- a/Sources/JWSETKit/Entities/JWE/JWECodable.swift
+++ b/Sources/JWSETKit/Entities/JWE/JWECodable.swift
@@ -89,7 +89,7 @@ extension JSONWebEncryption: Codable {
             throw DecodingError.dataCorrupted(.init(codingPath: codingPath, debugDescription: "JWE String is not a five part data."))
         }
         self.header = try JSONWebEncryptionHeader(protected: .init(encoded: sections[0] ?? .init()))
-        self.recipients = sections[1].map { [JSONWebEncryptionRecipient(encrypedKey: $0)] } ?? []
+        self.recipients = sections[1].map { [JSONWebEncryptionRecipient(encryptedKey: $0)] } ?? []
         let iv = sections[2]
         let ciphertext = sections[3]
         let tag = sections[4]

--- a/Sources/JWSETKit/Entities/JWE/JWERecipient.swift
+++ b/Sources/JWSETKit/Entities/JWE/JWERecipient.swift
@@ -16,7 +16,7 @@ import Foundation
 public struct JSONWebEncryptionRecipient: Hashable, Sendable, Codable {
     enum CodingKeys: String, CodingKey {
         case header
-        case encrypedKey = "encrypted_key"
+        case encryptedKey = "encrypted_key"
     }
     
     /// JWE Per-Recipient Unprotected Header.
@@ -30,27 +30,27 @@ public struct JSONWebEncryptionRecipient: Hashable, Sendable, Codable {
     ///
     /// A symmetric key for the AEAD algorithm used to encrypt the
     /// plaintext to produce the ciphertext and the Authentication Tag.
-    public var encrypedKey: Data
+    public var encryptedKey: Data
     
     /// Initializes a new recipient with given header and encrypted key.
     ///
     /// - Parameters:
     ///   - header: JWE Per-Recipient Unprotected Header.
+    public init(header: JOSEHeader? = nil, encryptedKey: Data) {
     ///   - encryptedKey: Content Encryption Key (CEK).
-    public init(header: JOSEHeader? = nil, encrypedKey: Data) {
         self.header = header
-        self.encrypedKey = encrypedKey
+        self.encryptedKey = encryptedKey
     }
     
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         self.header = try container.decodeIfPresent(JOSEHeader.self, forKey: JSONWebEncryptionRecipient.CodingKeys.header)
-        let b64Key = try container.decode(String.self, forKey: JSONWebEncryptionRecipient.CodingKeys.encrypedKey)
+        let b64Key = try container.decode(String.self, forKey: JSONWebEncryptionRecipient.CodingKeys.encryptedKey)
         guard let key = Data(urlBase64Encoded: b64Key) else {
-            throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath + [CodingKeys.encrypedKey], debugDescription: "Encrypted key is not a valid Base64URL"))
+            throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath + [CodingKeys.encryptedKey], debugDescription: "Encrypted key is not a valid Base64URL"))
         }
-        self.encrypedKey = key
+        self.encryptedKey = key
     }
     
     public func encode(to encoder: any Encoder) throws {
@@ -59,7 +59,7 @@ public struct JSONWebEncryptionRecipient: Hashable, Sendable, Codable {
         if let header, !header.storage.storageKeys.isEmpty {
             try container.encode(header, forKey: .header)
         }
-        try container.encode(encrypedKey.urlBase64EncodedString(), forKey: .encrypedKey)
+        try container.encode(encryptedKey.urlBase64EncodedString(), forKey: .encryptedKey)
     }
 }
 

--- a/Sources/JWSETKit/Entities/JWE/JWERecipient.swift
+++ b/Sources/JWSETKit/Entities/JWE/JWERecipient.swift
@@ -36,7 +36,7 @@ public struct JSONWebEncryptionRecipient: Hashable, Sendable, Codable {
     ///
     /// - Parameters:
     ///   - header: JWE Per-Recipient Unprotected Header.
-    ///   - encrypedKey: Content Encryption Key (CEK).
+    ///   - encryptedKey: Content Encryption Key (CEK).
     public init(header: JOSEHeader? = nil, encrypedKey: Data) {
         self.header = header
         self.encrypedKey = encrypedKey

--- a/Sources/JWSETKit/Entities/JWT/JWTOIDCStandard.swift
+++ b/Sources/JWSETKit/Entities/JWT/JWTOIDCStandard.swift
@@ -54,7 +54,7 @@ public struct JSONWebAddress: Hashable, Codable, Sendable {
     /// Country name component.
     public var country: String?
     
-    /// Initilizes the Address Claim represents a physical mailing address.
+    /// Initializes the Address Claim represents a physical mailing address.
     public init(formatted: String? = nil, streetAddress: String? = nil, locality: String? = nil, region: String? = nil, postalCode: String? = nil, country: String? = nil) {
         self.formatted = formatted
         self.streetAddress = streetAddress


### PR DESCRIPTION
- Commits are separated by individual words, allowing you to skip any word you’d prefer not to modify.
<sub>💡 It might be worthwhile to enable the spellchecking feature in contributors’ IDEs to catch errors early.</sub>
- Tests are passing