### PR TITLE
Refactor: Create a separate test for the commented-out expectation to ensure it’s recognized by the engine.

### DIFF
--- a/Tests/JWSETKitTests/Cryptography/JWKSetTests.swift
+++ b/Tests/JWSETKitTests/Cryptography/JWKSetTests.swift
@@ -104,9 +104,7 @@ struct JWKSetTests {
     @Test
     func testDecode() throws {
         let jwks = try JSONDecoder().decode(JSONWebKeySet.self, from: jwksData)
-        let jwksPublic = try JSONDecoder().decode(JSONWebKeySet.self, from: jwksPublicData)
         try #require(jwks.count == 2)
-//        #expect(jwks.publicKeyset == jwksPublic)
         #expect(jwks.publicKeyset[0] is (any JSONWebValidatingKey))
         #expect(jwks.publicKeyset[0] is JSONWebECPublicKey)
         
@@ -125,7 +123,15 @@ struct JWKSetTests {
         #expect(jwks[1].issuedAt == .init(timeIntervalSince1970: 123_972_394_872))
         #expect(jwks[1].revoked == JSONWebKeyRevocation(at: .init(timeIntervalSince1970: 123_972_495_172), for: .compromised))
     }
-    
+
+    @Test(.disabled("The expectation was initially commented out."))
+    func testDecodePublic() throws {
+        let jwks = try JSONDecoder().decode(JSONWebKeySet.self, from: jwksData)
+        let jwksPublic = try JSONDecoder().decode(JSONWebKeySet.self, from: jwksPublicData)
+        try #require(jwks.count == 2)
+        #expect(jwks.publicKeyset == jwksPublic)
+    }
+
     @Test
     func testEncode() throws {
         let jwks = try JSONDecoder().decode(JSONWebKeySet.self, from: jwksData)


### PR DESCRIPTION
This test now compiles but is isolated to ensure it doesn’t interfere with the existing test plan.