### PR TITLE
🔧 Fix build issue by pinning swift-crypto to 3.10.2

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -26,7 +26,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMinor(from: "1.1.0")),
         .package(url: "https://github.com/apple/swift-asn1.git", .upToNextMajor(from: "1.3.1")),
-        .package(url: "https://github.com/apple/swift-crypto.git", .upToNextMajor(from: "3.10.0")),
+        .package(url: "https://github.com/apple/swift-crypto.git", exact: "3.10.2"),
         .package(url: "https://github.com/apple/swift-certificates", .upToNextMajor(from: "1.7.0")),
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMajor(from: "1.8.4")),
     ],


### PR DESCRIPTION
This PR fixes a build issue caused by a bug in the swift-crypto dependency.

• Issue: The project fails to build due to an error related to swift-crypto.
• Fix: Explicitly pin swift-crypto to version 3.10.2, as recommended by the library author. #18 

Reference: [apple/swift-crypto#329](https://github.com/apple/swift-crypto/issues/329)