### PR TITLE
feat: relax HTTP status code checks to support any 2xx success codes

### DIFF
--- a/Sources/JWSETKit/Network/FoundationNetwork.swift
+++ b/Sources/JWSETKit/Network/FoundationNetwork.swift
@@ -36,7 +36,7 @@ enum URLSessionHTTPFetch: HTTPFetch {
             throw HTTPError.connectionError
         }
         switch response.statusCode {
-        case 200:
+        case 200 ..< 300:
             return data
         default:
             throw HTTPError.fromStatus(response.statusCode)

--- a/Sources/JWSETKit/Network/NIOHTTP1.swift
+++ b/Sources/JWSETKit/Network/NIOHTTP1.swift
@@ -80,7 +80,7 @@ enum HTTPClientFetch: HTTPFetch {
     static func fetch(url: URL) async throws -> Data {
         let request = HTTPClientRequest(url: url.absoluteString)
         let response = try await HTTPClient.shared.execute(request, timeout: .seconds(30))
-        if response.status == .ok {
+        if (200 ..< 300).contains(response.status.code) {
             var body = try await response.body.collect(upTo: 64 * 1024 * 1024) // 64 MB
             return Data(body.readBytes(length: body.readableBytes) ?? .init())
         } else {


### PR DESCRIPTION
Previously, network requests in the library only treated 200 OK as a successful response. While common, this is overly strict and can cause valid requests to fail when interacting with standards-compliant servers or CDNs that return other successful HTTP status codes, such as 201 Created or 204 No Content (please double-check the 204 No Content behavior).

To address this, I updated both the Foundation-based and SwiftNIO-based network layers to treat any 2xx HTTP status code (200–299) as success. This behavior aligns with the HTTP semantics defined in RFC 9110.

Let me know what you think.
Thanks