### PR TITLE
fix: broken hashing and inefficient equality check

### DIFF
--- a/Sources/JWSETKit/Base/Storage.swift
+++ b/Sources/JWSETKit/Base/Storage.swift
@@ -178,8 +178,8 @@ public struct JSONWebValueStorage: Codable, Hashable, Collection, CustomReflecta
     
     private static func hashValue(_ value: any Sendable, into hasher: inout Hasher) {
         switch value {
-        case let value as any Hashable:
-            hasher.combine(value)
+        case let value as JSONWebValueStorage:
+            value.hash(into: &hasher)
         case let value as [any Sendable]:
             hasher.combine(value.count)
             for element in value {
@@ -194,8 +194,8 @@ public struct JSONWebValueStorage: Codable, Hashable, Collection, CustomReflecta
                     hashValue(subValue, into: &hasher)
                 }
             }
-        case let value as JSONWebValueStorage:
-            value.hash(into: &hasher)
+        case let value as any Hashable:
+            hasher.combine(value)
         default:
             // Fallback to stable string representation if possible, or skip
             // Using AnyCodable to get a stable representation if it's at least Encodable

--- a/Sources/JWSETKit/Base/Storage.swift
+++ b/Sources/JWSETKit/Base/Storage.swift
@@ -165,8 +165,44 @@ public struct JSONWebValueStorage: Codable, Hashable, Collection, CustomReflecta
     }
     
     public func hash(into hasher: inout Hasher) {
-        let hashable = storage as any Hashable
-        hasher.combine(hashable)
+        // Sort keys to ensure stable hashing
+        let keys = storage.keys.sorted()
+        hasher.combine(keys.count)
+        for key in keys {
+            hasher.combine(key)
+            if let value = storage[key] {
+                JSONWebValueStorage.hashValue(value, into: &hasher)
+            }
+        }
+    }
+    
+    private static func hashValue(_ value: any Sendable, into hasher: inout Hasher) {
+        switch value {
+        case let value as any Hashable:
+            hasher.combine(value)
+        case let value as [any Sendable]:
+            hasher.combine(value.count)
+            for element in value {
+                hashValue(element, into: &hasher)
+            }
+        case let value as [String: any Sendable]:
+            let keys = value.keys.sorted()
+            hasher.combine(keys.count)
+            for key in keys {
+                hasher.combine(key)
+                if let subValue = value[key] {
+                    hashValue(subValue, into: &hasher)
+                }
+            }
+        case let value as JSONWebValueStorage:
+            value.hash(into: &hasher)
+        default:
+            // Fallback to stable string representation if possible, or skip
+            // Using AnyCodable to get a stable representation if it's at least Encodable
+            if value is any Encodable, let data = try? JSONEncoder().encode(AnyCodable(value)) {
+                hasher.combine(data)
+            }
+        }
     }
     
     /// Creates a storage by merging the given storages into this storage,

--- a/Tests/JWSETKitTests/Base/StorageTests.swift
+++ b/Tests/JWSETKitTests/Base/StorageTests.swift
@@ -146,4 +146,55 @@ struct StorageTests {
         storage2.storage = ["obj": NonHashableConformingEncodable(id: 2, name: "test")]
         #expect(storage1.hashValue != storage2.hashValue)
     }
+
+    @Test
+    func hashValueNestedStorage() {
+        var nested1 = JSONWebValueStorage()
+        nested1.storage = ["a": 1]
+        
+        var nested2 = JSONWebValueStorage()
+        nested2.storage = ["a": 1]
+        
+        var storage1 = JSONWebValueStorage()
+        storage1.storage = ["nested": nested1]
+        
+        var storage2 = JSONWebValueStorage()
+        storage2.storage = ["nested": nested2]
+        
+        #expect(storage1.hashValue == storage2.hashValue)
+        
+        nested2.storage = ["a": 2]
+        storage2.storage = ["nested": nested2]
+        #expect(storage1.hashValue != storage2.hashValue)
+    }
+
+    @Test
+    func hashValueDeeplyNestedStorage() {
+        var s3 = JSONWebValueStorage()
+        s3.storage = ["end": 3]
+        
+        var s2 = JSONWebValueStorage()
+        s2.storage = ["mid": s3]
+        
+        var s1 = JSONWebValueStorage()
+        s1.storage = ["top": s2]
+        
+        let h1 = s1.hashValue
+        
+        var s3b = JSONWebValueStorage()
+        s3b.storage = ["end": 3]
+        
+        var s2b = JSONWebValueStorage()
+        s2b.storage = ["mid": s3b]
+        
+        var s1b = JSONWebValueStorage()
+        s1b.storage = ["top": s2b]
+        
+        #expect(h1 == s1b.hashValue)
+        
+        s3b.storage = ["end": 4]
+        s2b.storage = ["mid": s3b]
+        s1b.storage = ["top": s2b]
+        #expect(h1 != s1b.hashValue)
+    }
 }

--- a/Tests/JWSETKitTests/Base/StorageTests.swift
+++ b/Tests/JWSETKitTests/Base/StorageTests.swift
@@ -87,6 +87,20 @@ struct StorageTests {
     }
     
     @Test
+    func hashCollisionForSameKeyAndSameNestedValues() {
+        var storage1 = JSONWebValueStorage()
+        storage1.storage = ["key": ["a", "b"]]
+
+        var storage2 = JSONWebValueStorage()
+        storage2.storage = ["key": ["a", "b"]]
+
+        let h1 = storage1.hashValue
+        let h2 = storage2.hashValue
+
+        #expect(h1 == h2)
+    }
+
+    @Test
     func hashCollisionForSameKeyAndDifferentValues() {
         var storage1 = JSONWebValueStorage()
         storage1.storage = ["a": 1]
@@ -98,5 +112,19 @@ struct StorageTests {
         let h2 = storage2.hashValue
         
         #expect(h1 != h2)
+    }
+
+    @Test
+    func hashCollisionForSameKeyAndSameValues() {
+        var storage1 = JSONWebValueStorage()
+        storage1.storage = ["a": 1]
+
+        var storage2 = JSONWebValueStorage()
+        storage2.storage = ["a": 1]
+
+        let h1 = storage1.hashValue
+        let h2 = storage2.hashValue
+
+        #expect(h1 == h2)
     }
 }

--- a/Tests/JWSETKitTests/Base/StorageTests.swift
+++ b/Tests/JWSETKitTests/Base/StorageTests.swift
@@ -127,4 +127,23 @@ struct StorageTests {
 
         #expect(h1 == h2)
     }
+
+    @Test
+    func hashNonHashableConformingEncodableValue() {
+        struct NonHashableConformingEncodable: Encodable, Sendable {
+            let id: Int
+            let name: String
+        }
+
+        var storage1 = JSONWebValueStorage()
+        storage1.storage = ["obj": NonHashableConformingEncodable(id: 1, name: "test")]
+
+        var storage2 = JSONWebValueStorage()
+        storage2.storage = ["obj": NonHashableConformingEncodable(id: 1, name: "test")]
+
+        #expect(storage1.hashValue == storage2.hashValue)
+
+        storage2.storage = ["obj": NonHashableConformingEncodable(id: 2, name: "test")]
+        #expect(storage1.hashValue != storage2.hashValue)
+    }
 }

--- a/Tests/JWSETKitTests/Base/StorageTests.swift
+++ b/Tests/JWSETKitTests/Base/StorageTests.swift
@@ -69,4 +69,34 @@ struct StorageTests {
         let secret = try SharedSecret(from: data)
         #expect(data == secret.data)
     }
+
+    // MARK: Hashing Tests
+
+    @Test
+    func hashCollisionForSameKeyAndDifferentNestedValues() {
+        var storage1 = JSONWebValueStorage()
+        storage1.storage = ["key": ["a", "b"]]
+        
+        var storage2 = JSONWebValueStorage()
+        storage2.storage = ["key": ["nested": "value"]]
+        
+        let h1 = storage1.hashValue
+        let h2 = storage2.hashValue
+        
+        #expect(h1 != h2)
+    }
+    
+    @Test
+    func hashCollisionForSameKeyAndDifferentValues() {
+        var storage1 = JSONWebValueStorage()
+        storage1.storage = ["a": 1]
+        
+        var storage2 = JSONWebValueStorage()
+        storage2.storage = ["a": 2]
+        
+        let h1 = storage1.hashValue
+        let h2 = storage2.hashValue
+        
+        #expect(h1 != h2)
+    }
 }


### PR DESCRIPTION
I fixed a critical hashing bug and optimized equality checks in `JSONWebValueStorage` to improve reliability and performance. (I did write 2 tests to prove the issue before touching the code. You can check out to the point and double-check if you need to)

Problem
1. Broken Hashing:
The previous implementation attempted to cast the underlying `[String: any Sendable]` dictionary to `any Hashable`. Since Swift dictionaries with existential values are not automatically `Hashable`, this resulted in incorrect behavior where different storage contents would often produce identical hash values (collisions).

2. Inefficient Equality: 
Equality checks relied heavily on **expensive** `JSONEncoder` serialization for any non-trivial comparison, leading to significant performance overhead when used in collections or high-frequency operations

Changes
1. Implemented a manual `hash(into:)` that recursively hashes keys and values. It correctly handles nested arrays, dictionaries, and primitive types.

2. Keys are now `sorted()` before hashing to ensure consistent hash values regardless of dictionary insertion order.

3. Replaced the `JSONEncoder` fallback with a recursive comparison of nested collections, significantly reducing memory allocations and CPU usage. (maybe a benchmark needed)

4. Added targeted test cases to verify both uniqueness (unrelated values) and equality (identical values) for both simple and nested structures.

Please let me know what you think 
Thanks