### PR TITLE
fix: resolve Tuist build issue for iOS projects

### DIFF
--- a/Sources/JWSETKit/Extensions/LockValue.swift
+++ b/Sources/JWSETKit/Extensions/LockValue.swift
@@ -633,7 +633,7 @@ public protocol DictionaryInitialzable: ExpressibleByDictionaryLiteral {
 }
 
 extension Dictionary: DictionaryInitialzable {}
-extension OrderedDictionary: DictionaryInitialzable {}
+extension OrderedCollections.OrderedDictionary: DictionaryInitialzable {}
 
 extension LockedValue: ExpressibleByDictionaryLiteral where Value: ExpressibleByDictionaryLiteral & DictionaryInitialzable, Value.Key: Hashable {
     @inlinable


### PR DESCRIPTION
## Purpose

Fix a build error when using this library in an iOS project that generates the workspace using **Tuist**.

## Problem

The current code uses `OrderedDictionary` without its module prefix:

```swift
extension OrderedDictionary: DictionaryInitialzable {}
```

In a standard Xcode project, this works because the type is visible in the global namespace. However, it seems that Tuist generates projects with stricter module boundaries and more isolated import handling. As a result, the compiler cannot resolve OrderedDictionary and fails the build.

## Solution

Qualify OrderedDictionary with its explicit module name:

```swift
extension OrderedCollections.OrderedDictionary: DictionaryInitialzable {}
```

This makes the type resolution explicit and works correctly in both Standard Xcode projects and Tuist‑generated projects.

No other logic or API is changed.